### PR TITLE
Change hackportal link to correct repository

### DIFF
--- a/components/open_source/HackPortalButton.js
+++ b/components/open_source/HackPortalButton.js
@@ -131,7 +131,7 @@ function HackPortalButton() {
           <Description>
             All-in-one hackathon management software. Modular and secure.
           </Description>
-          <LearnMore href="https://github.com/acmutd/hackportal-hackutd">Learn More <FaChevronCircleRight /></LearnMore>
+          <LearnMore href="https://github.com/acmutd/hackportal">Learn More <FaChevronCircleRight /></LearnMore>
         </RightContent>
       </SubContainer>
 


### PR DESCRIPTION
The old link pointed to our hackutd viii site instead of the current [hackportal repo](https://github.com/acmutd/hackportal)